### PR TITLE
Update ThermostatModeSwitch.hms

### DIFF
--- a/ThermostatModeSwitch.hms
+++ b/ThermostatModeSwitch.hms
@@ -69,14 +69,14 @@ foreach(deviceid, dom.GetObject(ID_DEVICES).EnumUsedIDs())
 {
     var device  = dom.GetObject(deviceid);                                                                  if(debug){WriteLine("Device:"#device#" (id:"#deviceid#")");}
                                                     
-    if( "HM-CC-RT-DN" == device.HSSID() )
+    if( "HM-CC-RT-DN" == device.HssType() )
     {   
         string channelid;                                                                                                           
         foreach(channelid,device.Channels().EnumUsedIDs())
         {
             var channel = dom.GetObject(channelid);                                                         if(debug){WriteLine("\t Channel:"#channel#" (id:"#channelid#")");}
             
-            if( "CLIMATECONTROL_RT_TRANSCEIVER" == channel.HSSID() )
+            if( "CLIMATECONTROL_RT_TRANSCEIVER" == channel.HssType() )
             {
                 var     interface   =   dom.GetObject(channel.Interface());
                 var     datapoint   =   interface#"."#channel.Address();                                    if(debug){WriteLine("\t Datapoint:"#datapoint);}


### PR DESCRIPTION
The methode .HSSID() is only working for datapoints, not for channels and not for devices. While e.g. 
var x = channel.HSSID();
causes an runtime error, is 
if( "CLIMATECONTROL_RT_TRANSCEIVER" == channel.HssType() )
simply evaluated always to TRUE. In the old version the inner block is evaluateted for every channel in the CCU!